### PR TITLE
Fix a few device quirks

### DIFF
--- a/Minisceop_DAQ/cyfxuvcdscr.c
+++ b/Minisceop_DAQ/cyfxuvcdscr.c
@@ -386,7 +386,7 @@ const uint8_t CyFxUSBHSConfigDscr[] =
                                          * D18: Contrast, Auto
                                          * D19 � D23: Reserved. Set to zero.
                                          */
-        0x01,0x00,0x00,                 /* bmControls field of processing unit: Brightness control supported */
+        0x3F,0x02,0x00,                 /* bmControls field of processing unit, Supported: Brightness; Contrast; Hue; Saturation; Sharpness; Gamma; Gain */
         0x00,                           /* String desc index : Not used */
 #ifndef FX3_UVC_1_0_SUPPORT
         0x00,                           /* Analog Video Standards Supported: None */
@@ -716,7 +716,7 @@ const uint8_t CyFxUSBSSConfigDscr[] =
         0x01,                           /* Source ID : 1 : Connected to input terminal */
         0x00,0x40,                      /* Digital multiplier */
         0x03,                           /* Size of controls field for this terminal : 3 bytes */
-        0xFF,0x02,0x00,                 /* bmControls field of processing unit: Brightness control supported */
+        0x3F,0x02,0x00,                 /* bmControls field of processing unit, Supported: Brightness; Contrast; Hue; Saturation; Sharpness; Gamma; Gain */
         0x00,                           /* String desc index : Not used */
 #ifndef FX3_UVC_1_0_SUPPORT
         0x00,                           /* Analog Video Standards Supported: None */
@@ -754,7 +754,7 @@ const uint8_t CyFxUSBSSConfigDscr[] =
         0x01,                           /* Number of input pins in this terminal */
         0x02,                           /* Source ID : 2 : Connected to Proc Unit */
         0x03,                           /* Size of controls field for this terminal : 3 bytes */
-        0xFF,0x02,0x00,                 /* No controls supported */ //MINISCOPE: Maybe can be set to all 0x00
+        0x3F,0x02,0x00,                 /* Supported controls: Brightness; Contrast; Hue; Saturation; Sharpness; Gamma; Gain */
         0x00,                           /* String desc index : Not used */
 #endif
 

--- a/Minisceop_DAQ/uvc.c
+++ b/Minisceop_DAQ/uvc.c
@@ -1339,14 +1339,26 @@ UVCHandleProcessingUnitRqts (
 						CyU3PUsbSendEP0Data (2, (uint8_t *)glEp0Buffer);
                     }
                     break;
-                case CY_FX_USB_UVC_GET_MIN_REQ: /* Minimum brightness = 0. */
-                    glEp0Buffer[0] = 0;
-                    glEp0Buffer[1] = 0;
+                case CY_FX_USB_UVC_GET_MIN_REQ:
+                    if ((wValue == CY_FX_UVC_PU_HUE_CONTROL) || (wValue == CY_FX_UVC_PU_BRIGHTNESS_CONTROL)) {
+                        /* these values are signed, so we sent the lower signed integer limit */
+                        glEp0Buffer[0] = 0x00;
+                        glEp0Buffer[1] = 0x80;
+		    } else {
+                       glEp0Buffer[0] = 0;
+                       glEp0Buffer[1] = 0;
+		    }
                     CyU3PUsbSendEP0Data (2, (uint8_t *)glEp0Buffer);
                     break;
-                case CY_FX_USB_UVC_GET_MAX_REQ: /* Maximum brightness = 255. */
-                    glEp0Buffer[0] = 255;
-                    glEp0Buffer[1] = 255;
+                case CY_FX_USB_UVC_GET_MAX_REQ:
+                    if ((wValue == CY_FX_UVC_PU_HUE_CONTROL) || (wValue == CY_FX_UVC_PU_BRIGHTNESS_CONTROL)) {
+                        /* these values are signed, so we sent the upper signed integer limit */
+                        glEp0Buffer[0] = 0xFF;
+                        glEp0Buffer[1] = 0x7F;
+		    } else {
+                       glEp0Buffer[0] = 0xFF;
+                       glEp0Buffer[1] = 0xFF;
+		    }
                     CyU3PUsbSendEP0Data (2, (uint8_t *)glEp0Buffer);
                     break;
                 case CY_FX_USB_UVC_GET_RES_REQ: /* Resolution = 1. */


### PR DESCRIPTION
Hi!
This is a follow-up on https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/pull/4
I was investigating why the Miniscope software wasn't working on Linux, going through the layers of OpenCV -> v4l-libs -> kernel driver -> firmware and found out that there were two issues with the device:
 * The device was advertising to support more stream controls than it actually could, resulting in the driver invalidating a whole block of controls (gamma, saturation, sharpness), likely due to heuristics meant to work around faulty hardware. The first patch in this series fixes that, advertising only actually supported controls in `bmControls`
 * The device was attempting to return *unsigned* integers for which the USB UVC specification requires *signed* integers, namely for HUE and BRIGHTNESS. Since `0xFFFF` is -1 in signed-int form, the system assumes a max value of -1 and a minimum value of 0. The driver performs value sanitization, clamping the sent values to their min/max range before the device sees them, so any value submitted by an application will be lost (same applies to values sent *from* the device) I have no idea why this particular issue isn't seen on Windows, apparently that OS is very forgiving.

With these patches applied, I get zero warnings from the kernel when the device is plugged in. I can write all control values and read the same values back from the device. I can also watch the correct values being transferred when intercepting USB communication.
And yet for some reason the LED intensity on my v3 Miniscope still doesn't change. I have never tested this on Windows, so there is a chance that the v3 support doesn't fully work on any platform. I will have to verify that somehow and then test again. Or maybe someone else has an idea what else could be wrong here (I haven't yet figured out how to debug the device itself while it's running).

In any case, these patches should already be helpful to some extent, and definitely resolve some issues on Linux.
Thanks for considering!
Cheers,
    Matthias

P.S: I had to resist the urge to clean up the repository (that -metadata folder should likley go into .gitignore) and fix the typo in the source folder name ^^